### PR TITLE
It loops!

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,9 +3,12 @@
   <meta charset="utf-8">
   <title>MIDI Looper</title>
   <link rel="stylesheet" href="layout.css">
+  <script src="https://unpkg.com/preact@8.2.6/dist/preact.min.js"></script>
+  <script src="https://unpkg.com/unistore@2.3.0/dist/unistore.umd.js"></script>
 </head><body>
   <h1>MIDI Looper</h1>
   <p>*— Keep MIDI Loopy —*</p>
   
+  <div id="app"></div>
   <script src="main.js"></script>
 </body></html>

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html><head>
+  <meta charset="utf-8">
+  <title>MIDI Looper</title>
+  <link rel="stylesheet" href="layout.css">
+</head><body>
+  <h1>MIDI Looper</h1>
+  <p>*— Keep MIDI Loopy —*</p>
+  
+  <script src="main.js"></script>
+</body></html>

--- a/app/layout.css
+++ b/app/layout.css
@@ -1,0 +1,3 @@
+body {
+  font-family: sans-serif;
+}

--- a/app/layout.css
+++ b/app/layout.css
@@ -1,3 +1,14 @@
 body {
   font-family: sans-serif;
 }
+
+.midi-controls {
+  float: left;
+  margin: 0 1em;
+}
+
+.main-switch {
+  display: block;
+  margin: 0.5em auto;
+  font-size: 5em;
+}

--- a/app/main.js
+++ b/app/main.js
@@ -262,11 +262,6 @@ class Looper {
     return this.recording;
   }
   
-  _queueRepeat(nextStart) {     // TODO: split into "track" class that queues only ~30ms of events
-    let offset = nextStart - this.startTime
-    this.events.forEach(({data,time}) => this.beeper.send(data,time+offset))
-  }
-  
   startPlayback() {
     let events = this.events.map(({data,time}) => ({data,time:time-this.startTime}))
     let duration = this.endTime - this.startTime

--- a/app/main.js
+++ b/app/main.js
@@ -1,1 +1,69 @@
-console.log("WAKAWAKA");
+"use strict";
+
+class Looper {
+  constructor() {
+    this.log = evt => console.log(evt)
+  }
+  
+  use(port) {
+    let { port:prev, log } = this
+    console.log("LOG?", log, port)
+    if (prev) prev.removeEventListener('midimessage', log, true)
+    if (port) port.onmidimessage = function (msg) { console.log(msg); };
+    this.port = port
+    console.log("Using", port)
+  }
+}
+
+let looper = new Looper()
+
+
+const { createStore } = unistore
+
+let store = createStore({ inputs:null, input:null })
+
+let actions = store => ({
+  selectInput({ input:prev }, port) {
+    looper.use(port)
+  }
+})
+
+const { Component, render, h } = preact
+const { Provider, connect } = unistore
+
+let SourceSelector = ({ inputs }) => h('div', {class:"source-selector"},
+  h('h2', {}, "MIDI Input"),
+  (inputs) ? h('select', {
+    onChange: evt => {
+      let idx = evt.target.selectedIndex - 1  // (account for --- option)
+      looper.use(inputs[idx] || null)
+    }
+  },
+    h('option', {}, '---'),
+    inputs.map(obj => h('option', {
+      'myprop': obj
+    }, obj.name))
+  ) : h('span', {}, "No inputs.")
+)
+
+let App = connect(s => s)(({ inputs }) => h('div', {},
+  h(SourceSelector, {inputs})
+))
+
+render(h(Provider, {store},
+  h(App)
+), document.getElementById('app'))
+
+
+async function run() {
+  try {
+    // TODO: move this to Looper
+    let midi = await navigator.requestMIDIAccess(/*{sysex:true}*/)
+    let inputs = Array.from(midi.inputs.values())
+    store.setState({inputs})
+  } catch (e) {
+    console.error("Failed to gain MIDI access.", e)
+  }
+}
+
+run()

--- a/app/main.js
+++ b/app/main.js
@@ -164,7 +164,7 @@ class Looper {
       data: evt.data,
       time: evt.timeStamp
     })
-    this.beeper.send(evt.data, evt.timeStamp/* + 1000*/)
+    this.beeper.send(evt.data, evt.timeStamp)
   }
   
   use(port) {
@@ -194,9 +194,21 @@ class Looper {
 console.log( (this.recording) ? "RECORDING" : "PLAYING" )
   }
   
+  _queueRepeat(i) {
+    let nextStart = performance.now() + i * (this.endTime - this.startTime)
+    let offset = nextStart - this.startTime
+    this.events.forEach(({data,time}) => this.beeper.send(data,time+offset))
+  }
+  
   
   startPlayback() {
-    
+    let i = 0
+    let delay = this.endTime - this.startTime - 0.5
+    let trigger = function () {
+      this._queueRepeat(i++)
+      setTimeout(trigger, delay / 1000)
+    }.bind(this)
+    trigger()
   }
   
   stopPlayback() {}

--- a/app/main.js
+++ b/app/main.js
@@ -114,7 +114,8 @@ class Looper {
     let inputs = Array.from(this.midi.inputs.values())
     let {input} = store.getState()
     if (input && input.state === 'disconnected') this.use(input = null)
-    this.store.setState({inputs})
+    this.store.setState({inputs,input})
+    if (!input && inputs.length === 1) this.use(input = inputs[0])
   }
   
   BIND_handleMessage(evt) {

--- a/app/main.js
+++ b/app/main.js
@@ -3,7 +3,7 @@
 
 const { createStore } = unistore
 
-let store = createStore({ inputs:null, input:null })
+let store = createStore({ inputs:null, input:null, status:null })
 
 const { Component, render, h } = preact
 const { Provider, connect } = unistore
@@ -30,7 +30,10 @@ class RecordButton extends Component {
   }
   
   BIND_handleToggle(evt) {
-    if (evt.type === 'click' || evt.code === "Space") looper.toggleRecording(evt)
+    if (evt.type === 'click' || evt.code === "Space") {
+      let recording = looper.toggleRecording(evt)
+      this.setState({recording})
+    }
   }
   
   componentDidMount() {
@@ -40,7 +43,8 @@ class RecordButton extends Component {
     window.removeEventListener('keyup', this.handleToggle, false)
   }
   render() {
-    return h('button', {type:'button',onClick:this.handleToggle}, "Record")
+    let recording = this.state.recording
+    return h('button', {type:'button',onClick:this.handleToggle}, (recording) ? "Play" : "Record")
   }
 }
 
@@ -48,8 +52,6 @@ let App = connect(s => s)(({ inputs,input }) => h('div', {},
   h(SourceSelector, {inputs,input}),
   h(RecordButton, {})
 ))
-
-render(h(Provider, {store}, h(App)), document.getElementById('app'))
 
 
 class Beeper {
@@ -196,7 +198,7 @@ class Looper {
       this.stopRecording(evt.timeStamp)
       this.startPlayback()
     }
-console.log( (this.recording) ? "RECORDING" : "PLAYING" )
+    return this.recording;
   }
   
   _queueRepeat(nextStart) {     // TODO: split into "track" class that queues only ~30ms of events
@@ -224,6 +226,9 @@ console.log( (this.recording) ? "RECORDING" : "PLAYING" )
   }
 }
 
+
 let beeper = new Beeper(),
     looper = new Looper(store)
 looper.start(beeper)
+
+render(h(Provider, {store}, h(App)), document.getElementById('app'))

--- a/app/main.js
+++ b/app/main.js
@@ -199,7 +199,7 @@ class Looper {
 console.log( (this.recording) ? "RECORDING" : "PLAYING" )
   }
   
-  _queueRepeat(nextStart) {
+  _queueRepeat(nextStart) {     // TODO: split into "track" class that queues only ~30ms of events
     let offset = nextStart - this.startTime
     this.events.forEach(({data,time}) => this.beeper.send(data,time+offset))
   }
@@ -208,11 +208,12 @@ console.log( (this.recording) ? "RECORDING" : "PLAYING" )
     this.playing = true
     let interval = this.endTime - this.startTime
     let trigger = function (now=performance.now()) {
+      if (!this.playing) return
+      
       let elapsed = now - this.endTime
       let idx = Math.ceil(elapsed / interval)
       this._queueRepeat(this.endTime + idx * interval)
-      
-      if (this.playing) setTimeout(trigger, interval - 50)
+      setTimeout(trigger, interval - 50)
     }.bind(this)
     trigger(this.endTime)
   }

--- a/app/main.js
+++ b/app/main.js
@@ -1,0 +1,1 @@
+console.log("WAKAWAKA");

--- a/app/main.js
+++ b/app/main.js
@@ -90,6 +90,7 @@ class Beeper {
   }
   
   _hiresToTime(t) {
+    if (t === 0) t = performance.now()
     // see https://webaudio.github.io/web-audio-api/#dom-audiocontext-getoutputtimestamp
     var at = this.ctx.getOutputTimestamp()
     return at.contextTime + (t - at.performanceTime) / 1000
@@ -113,6 +114,10 @@ class Beeper {
     this.schedule(n,0,t,0.05)
   }
   
+  stopAll(t=0) {
+    Object.keys(this.notes).forEach(n => this.schedule(n,0,t,0))
+  }
+  
   // c.f. https://www.w3.org/TR/webmidi/#midioutput-interface
   send(bytes, ts=0) {
     // TODO: handle multiple messages
@@ -124,6 +129,9 @@ class Beeper {
         break
       case 0x9:
         this.playNote(data1, data2, ts)
+        break
+      case 0xB:
+        if (data1 === 0x7B) this.stopAll(ts)
         break
     }
   }
@@ -182,6 +190,7 @@ class Track {
   stop() {
     this.playing = false
     this.output.clear()
+    this.output.send([0xB0, 0x7B, 0])     // all notes off
   }
 }
 


### PR DESCRIPTION
Release early, release often — right?

I have something that works just well enough to file bugs on. It roughly follows the architecture outline of  https://github.com/websound/midilooper/issues/1#issuecomment-350343789.



It has the following known issues:

- [x] interface is half baked, doesn't even show record status
- [x] queuing up of notes — and cancellation thereof — is very coarse grained [whole loop at a time]
- [x] no handling of half-fired notes [records ± raw MIDI messages, which means if an "on" happens before you press record, or an "off" happens after you stop…]
- [x] occasionally misfires random notes while recording [think I realized what this one was already]

and missing features:

- [ ] no overdub, undo/redo or even a good way to stop/resume
- [x] only sends to simple softsynth, needs a MIDI out dropdown
- [ ] option to disable "local echo" (i.e. avoid forwarding live input to output)
- [ ] ability to filter what sort of messages and/or which channel numbers are recorded

But here's how you use it:

1. Open the index.html file in Chrome
2. Connect a MIDI keyboard controller, or select from those already connected
3. Press "space" or click button — recording starts, invisibly
4. Play some notes
5. Press "space" or click button — playback starts

To stop playback right now, either press space twice to store an empty loop or refresh the page.